### PR TITLE
Replaced £ with (correct) Σ for sum function

### DIFF
--- a/utils/evaluator.php
+++ b/utils/evaluator.php
@@ -135,7 +135,7 @@ class Evaluator
                     $functionTotal = $columns[$c]->getFunctionTotal();
                     switch($functionTotal) {
                         case 'sum':
-                            $totalString = '(£) ' . $totalValue;
+                            $totalString = '(Σ) ' . $totalValue;
                             break;
                         case 'avg':
                             $totalString =  '(Ø) ' . sprintf("%01.1f",$totalValue / count($rows));


### PR DESCRIPTION
Changed sign for the sum function, because I think £ is wrong and Σ is correct.
* £ = https://de.wikipedia.org/wiki/£
* Σ = https://de.wikipedia.org/wiki/Σ